### PR TITLE
feat: add support for login with username

### DIFF
--- a/components/auth/login-card.tsx
+++ b/components/auth/login-card.tsx
@@ -7,8 +7,9 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import Link from "next/link";
-import { LoginWithEmailForm } from "./login-email-form";
+// import { LoginWithEmailForm } from "./login-email-form";
 import { LoginWithGitHubForm } from "./login-github-form";
+import { LoginWithUsernameForm } from "./login-username-form";
 
 export const LoginCard = () => {
   return (
@@ -22,7 +23,7 @@ export const LoginCard = () => {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <LoginWithEmailForm />
+        <LoginWithUsernameForm />
         <div className="mt-3 mb-1 flex flex-shrink items-center justify-center gap-2">
           <div className="grow basis-0 border-b border-border border-dashed" />
           <span className="text-xs font-normal uppercase leading-none text-neutral-500">

--- a/components/auth/login-username-form.tsx
+++ b/components/auth/login-username-form.tsx
@@ -1,0 +1,128 @@
+"use client";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormDescription,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { authClient } from "@/lib/auth-client";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import { LoadingCircle } from "../icons/loading-circle";
+
+const formSchema = z.object({
+  username: z
+    .string()
+    .min(3, { message: "Username must be at least 3 characters long." })
+    .max(30, { message: "Username must be at most 30 characters long." })
+    .refine((val) => /^[a-zA-Z0-9._-]+$/.test(val), {
+      message:
+        "Username can only contain letters, numbers, underscores (_), periods (.), or hyphens (-).",
+    })
+    .refine((val) => /^[a-zA-Z0-9]/.test(val), {
+      message: "Username must start with a letter or number.",
+    })
+    .refine((val) => /[a-zA-Z0-9]$/.test(val), {
+      message: "Username must end with a letter or number.",
+    })
+    .refine((val) => !/([_.-])\1/.test(val), {
+      message: "Username cannot contain consecutive special characters like __ or .. or --.",
+    }),
+  password: z
+    .string()
+    .min(8, { message: "Password must be at least 8 characters long." })
+    .refine((val) => /[A-Z]/.test(val), {
+      message: "Password must include at least one uppercase letter.",
+    })
+    .refine((val) => /[a-z]/.test(val), {
+      message: "Password must include at least one lowercase letter.",
+    })
+    .refine((val) => /[0-9]/.test(val), {
+      message: "Password must include at least one number.",
+    })
+    .refine((val) => /[^A-Za-z0-9]/.test(val), {
+      message: "Password must include at least one special character.",
+    }),
+});
+
+type FormSchemaType = z.infer<typeof formSchema>;
+
+export const LoginWithUsernameForm = () => {
+  const router = useRouter();
+
+  const form = useForm<FormSchemaType>({
+    defaultValues: {
+      username: "",
+      password: "",
+    },
+    resolver: zodResolver(formSchema),
+  });
+
+  async function onSubmit({ username, password }: FormSchemaType) {
+     await authClient.signIn.username(
+      {
+        username,
+        password,
+      },
+      {
+        onError: (ctx) => {
+          toast.error(ctx.error.message);
+        },
+        onSuccess : ()=>{
+          toast.success("Logged in successfully");
+          router.push("/dashboard")
+        }
+      }
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <fieldset className="flex flex-col gap-2" disabled={form.formState.isSubmitting}>
+          <FormField
+            control={form.control}
+            name="username"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel />
+                <FormDescription className="-my-1">
+                  Username
+                </FormDescription>
+                <FormControl>
+                  <Input placeholder="raydalio" {...field} />
+                </FormControl>
+                <FormMessage className="-my-1" />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel />
+                <FormDescription className="-my-1">Password</FormDescription>
+                <FormControl>
+                  <Input type="password" placeholder="********" {...field} />
+                </FormControl>
+                <FormMessage className="-my-1" />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="mt-3 flex justify-center items-center">
+            {form.formState.isSubmitting ? <LoadingCircle/> : "Login"}
+          </Button>
+        </fieldset>
+      </form>
+    </Form>
+  );
+};

--- a/components/auth/signup-email-form.tsx
+++ b/components/auth/signup-email-form.tsx
@@ -20,6 +20,24 @@ import { useRouter } from "next/navigation";
 
 const formSchema = z.object({
   email: z.string().email({ message: "Please use a valid email address" }),
+  name: z.string().min(1,{message : "Name is required"}),
+  username: z
+  .string()
+  .min(3, { message: "Username must be at least 3 characters long." })
+  .max(30, { message: "Username must be at most 30 characters long." })
+  .refine((val) => /^[a-zA-Z0-9._-]+$/.test(val), {
+    message:
+      "Username can only contain letters, numbers, underscores (_), periods (.), or hyphens (-).",
+  })
+  .refine((val) => /^[a-zA-Z0-9]/.test(val), {
+    message: "Username must start with a letter or number.",
+  })
+  .refine((val) => /[a-zA-Z0-9]$/.test(val), {
+    message: "Username must end with a letter or number.",
+  })
+  .refine((val) => !/([_.-])\1/.test(val), {
+    message: "Username cannot contain consecutive special characters like __ or .. or --.",
+  }),
   password: z
     .string()
     .min(8, { message: "Password must be at least 8 characters long." })
@@ -35,7 +53,6 @@ const formSchema = z.object({
     .refine((val) => /[^A-Za-z0-9]/.test(val), {
       message: "Password must include at least one special character.",
     }),
-  name: z.string(),
 });
 
 type FormSchemaType = z.infer<typeof formSchema>;
@@ -48,16 +65,18 @@ export const SignupEmailForm = () => {
       email: "",
       password: "",
       name: "",
+      username : "",
     },
     resolver: zodResolver(formSchema),
   });
 
-  async function onSubmit({ name, email, password }: FormSchemaType) {
+  async function onSubmit({ name, username,email, password }: FormSchemaType) {
     await authClient.signUp.email(
       {
         name,
         email,
         password,
+        username
       },
       {
         onError: (ctx) => {
@@ -87,6 +106,20 @@ export const SignupEmailForm = () => {
                 <FormDescription className="-my-1">Name</FormDescription>
                 <FormControl>
                   <Input placeholder="Ray Dalio" {...field} />
+                </FormControl>
+                <FormMessage className="-my-1" />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="username"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel />
+                <FormDescription className="-my-1">Username</FormDescription>
+                <FormControl>
+                  <Input placeholder="raydalio" {...field} />
                 </FormControl>
                 <FormMessage className="-my-1" />
               </FormItem>

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -1,5 +1,9 @@
 import { createAuthClient } from "better-auth/react"
+import { usernameClient } from "better-auth/client/plugins"
 
 export const authClient = createAuthClient({
     baseURL: "http://localhost:3000",
+    plugins : [
+        usernameClient()
+    ]
 })

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,61 +1,86 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import {prisma} from "@/lib/prisma" 
+import { prisma } from "@/lib/prisma";
 import { openAPI, username } from "better-auth/plugins";
+import slugify from "@sindresorhus/slugify";
+
+const generateRandomNumber = () => {
+  return Math.floor(Math.random() * 10000) + 1;
+};
+
+const generateUsername = (format: string) => {
+  return slugify(format) + generateRandomNumber();
+};
 
 export const auth = betterAuth({
-    appName : "Spool",
+  appName: "Spool",
 
-    database: prismaAdapter(prisma, {
-        provider: "postgresql",
+  database: prismaAdapter(prisma, {
+    provider: "postgresql",
+  }),
+  session: {
+    expiresIn: 60 * 60 * 24 * 7, // 7 days
+    updateAge: 60 * 60 * 24, // update active session every 1 day
+  },
+  socialProviders: {
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID as string,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+      enabled: true,
+    },
+  },
+  account: {
+    accountLinking: {
+      enabled: true,
+      trustedProviders: ["github"],
+    },
+  },
+  emailAndPassword: {
+    enabled: true,
+    minPasswordLength: 8,
+    maxPasswordLength: 128,
+    autoSignIn: true,
+    requireEmailVerification: true,
+    sendResetPassword: async ({ user, url }) => {
+      // TODO : send email in PROD
+      console.log(`Reset password link : ${url} for`, user);
+    },
+  },
+  emailVerification: {
+    sendOnSignUp: true,
+    autoSignInAfterVerification: true,
+    expiresIn: 60 * 60, // 1 hour
+    sendVerificationEmail: async ({ user, token }) => {
+      const verificationUrl = `${process.env.BETTER_AUTH_URL}/api/auth/verify-email?token=${token}&callbackURL=${process.env.EMAIL_VERIFICATION_CALLBACK_URL}`;
+      console.log(user);
+      console.log(verificationUrl);
+      // TODO : send email in PROD
+    },
+  },
+  rateLimit: {
+    enabled: true,
+  },
+  databaseHooks: {
+    user: {
+      create: {
+        // add username manually for social providers
+        before: async (user, ctx) => {
+          if (ctx?.request?.url.includes("github")) {
+            // add username manually here
+            const username = generateUsername(user.name);
+            return {
+              data: { ...user, username, displayUsername: username },
+            };
+          }
+        },
+      },
+    },
+  },
+  plugins: [
+    openAPI(),
+    username({
+      minUsernameLength: 5,
+      maxUsernameLength: 30,
     }),
-    session : {
-        expiresIn : 60 * 60 * 24 * 7, // 7 days
-        updateAge : 60 * 60 * 24 // update active session every 1 day
-    },
-    socialProviders : {
-        github : {
-            clientId : process.env.GITHUB_CLIENT_ID as string,
-            clientSecret : process.env.GITHUB_CLIENT_SECRET as string,
-            enabled : true,
-        },
-    },
-    account : {
-        accountLinking : {
-            enabled : true,
-            trustedProviders : ["github"]
-        }
-    },
-    emailAndPassword : {
-        enabled : true,
-        minPasswordLength : 8,
-        maxPasswordLength : 128,
-        autoSignIn : true,
-        requireEmailVerification : true,
-        sendResetPassword : async ({user,url})=>{
-            // TODO : send email in PROD
-            console.log(`Reset password link : ${url} for`, user);
-        }
-    },
-    emailVerification : {
-        sendOnSignUp : true,
-        autoSignInAfterVerification : true,
-        expiresIn : 60 * 60, // 1 hour
-        sendVerificationEmail : async ({user, token}) => {
-            const verificationUrl = `${process.env.BETTER_AUTH_URL}/api/auth/verify-email?token=${token}&callbackURL=${process.env.EMAIL_VERIFICATION_CALLBACK_URL}`;
-            console.log(user)
-            console.log(verificationUrl);
-            // TODO : send email in PROD
-        },
-    },
-    rateLimit : {
-        enabled : true
-    },
-    plugins : [
-        openAPI(),
-        username({
-            minUsernameLength : 5,
-            maxUsernameLength : 30,
-        })
-    ]
+  ],
 });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,7 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import {prisma} from "@/lib/prisma" 
-import { openAPI } from "better-auth/plugins";
+import { openAPI, username } from "better-auth/plugins";
 
 export const auth = betterAuth({
     appName : "Spool",
@@ -51,5 +51,11 @@ export const auth = betterAuth({
     rateLimit : {
         enabled : true
     },
-    plugins : [openAPI()]
+    plugins : [
+        openAPI(),
+        username({
+            minUsernameLength : 5,
+            maxUsernameLength : 30,
+        })
+    ]
 });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-label": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.6",
     "@radix-ui/react-slot": "^1.2.2",
+    "@sindresorhus/slugify": "^2.2.1",
     "better-auth": "^1.2.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.2
         version: 1.2.2(@types/react@19.1.2)(react@19.1.0)
+      '@sindresorhus/slugify':
+        specifier: ^2.2.1
+        version: 2.2.1
       better-auth:
         specifier: ^1.2.7
         version: 1.2.7
@@ -908,6 +911,14 @@ packages:
     resolution: {integrity: sha512-1hsLpRHfSuMB9ee2aAdh0Htza/X3f4djhYISrggqGe3xopNjOcePiSDkDDoPzDYaaMCrbqGP1H2TYU7bgL9PmA==}
     engines: {node: '>=20.0.0'}
 
+  '@sindresorhus/slugify@2.2.1':
+    resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
+    engines: {node: '>=12'}
+
+  '@sindresorhus/transliterate@1.6.0':
+    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
+    engines: {node: '>=12'}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -1433,6 +1444,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-next@15.3.1:
     resolution: {integrity: sha512-GnmyVd9TE/Ihe3RrvcafFhXErErtr2jS0JDeCSp3vWvy86AXwHsRBt0E3MqP/m8ACS1ivcsi5uaqjbhsG18qKw==}
@@ -3157,6 +3172,15 @@ snapshots:
       '@peculiar/asn1-schema': 2.3.15
       '@peculiar/asn1-x509': 2.3.15
 
+  '@sindresorhus/slugify@2.2.1':
+    dependencies:
+      '@sindresorhus/transliterate': 1.6.0
+      escape-string-regexp: 5.0.0
+
+  '@sindresorhus/transliterate@1.6.0':
+    dependencies:
+      escape-string-regexp: 5.0.0
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -3792,6 +3816,8 @@ snapshots:
       '@esbuild/win32-x64': 0.25.3
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-next@15.3.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3):
     dependencies:

--- a/prisma/migrations/20250508100702_add_username/migration.sql
+++ b/prisma/migrations/20250508100702_add_username/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `username` to the `user` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "displayUserName" TEXT,
+ADD COLUMN     "username" TEXT NOT NULL;

--- a/prisma/migrations/20250508101922_fix_username_casing/migration.sql
+++ b/prisma/migrations/20250508101922_fix_username_casing/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `displayUserName` on the `user` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "user" DROP COLUMN "displayUserName",
+ADD COLUMN     "displayUsername" TEXT;

--- a/prisma/migrations/20250508110441_add_unique_constranit_to_username/migration.sql
+++ b/prisma/migrations/20250508110441_add_unique_constranit_to_username/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[username]` on the table `user` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "user_username_key" ON "user"("username");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,15 +14,17 @@ datasource db {
 }
 
 model User {
-  id            String    @id
-  name          String
-  email         String
-  emailVerified Boolean
-  image         String?
-  createdAt     DateTime
-  updatedAt     DateTime
-  sessions      Session[]
-  accounts      Account[]
+  id              String    @id
+  name            String
+  username        String
+  displayUsername String?
+  email           String
+  emailVerified   Boolean
+  image           String?
+  createdAt       DateTime
+  updatedAt       DateTime
+  sessions        Session[]
+  accounts        Account[]
 
   @@unique([email])
   @@map("user")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ datasource db {
 model User {
   id              String    @id
   name            String
-  username        String
+  username        String    @unique
   displayUsername String?
   email           String
   emailVerified   Boolean


### PR DESCRIPTION
Fixes #3 

## Proposed Changes
- This PR adds two fields to `Users` model : `username` and `displayUsername` and migrates the database schema. 
- We add support for users opting for authentication using credentials to choose their own username and use it for authentication every time.
- Additionally to keep compatibility with users opting authentication using Github OAuth, we manually assign a default username which is a combination to users name (take from GitHub) and a random number between 1 to 10000. 
- Users will be given the option to change the username after they login. So users with OAuth can always personalize their username

Note that, users can't use both authentication methods. (Probably I'll give an option to manually link GitHub for users opting authentication with credentials. But it isn't supported as of now.)