### PR TITLE
feat: database design and migration using prisma schema

### DIFF
--- a/prisma/migrations/20250509052139_add_models_workspace_folder_snippet_comment_comment_like_snippet_star_and_constraints/migration.sql
+++ b/prisma/migrations/20250509052139_add_models_workspace_folder_snippet_comment_comment_like_snippet_star_and_constraints/migration.sql
@@ -1,0 +1,149 @@
+-- CreateTable
+CREATE TABLE "workspace" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "slug" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "workspace_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "folder" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "ownerId" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "folder_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Snippet" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "code" TEXT NOT NULL,
+    "public" BOOLEAN NOT NULL DEFAULT true,
+    "folderId" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "startCount" INTEGER NOT NULL DEFAULT 0,
+    "commentCount" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Snippet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "comment" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "snippetId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "comment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "comment_like" (
+    "id" TEXT NOT NULL,
+    "commentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "comment_like_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "snippet_star" (
+    "id" TEXT NOT NULL,
+    "snippetId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "snippet_star_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "workspace_slug_key" ON "workspace"("slug");
+
+-- CreateIndex
+CREATE INDEX "workspace_ownerId_idx" ON "workspace"("ownerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "workspace_ownerId_name_key" ON "workspace"("ownerId", "name");
+
+-- CreateIndex
+CREATE INDEX "folder_ownerId_idx" ON "folder"("ownerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "folder_workspaceId_ownerId_name_key" ON "folder"("workspaceId", "ownerId", "name");
+
+-- CreateIndex
+CREATE INDEX "Snippet_authorId_folderId_workspaceId_idx" ON "Snippet"("authorId", "folderId", "workspaceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Snippet_folderId_name_key" ON "Snippet"("folderId", "name");
+
+-- CreateIndex
+CREATE INDEX "comment_snippetId_authorId_idx" ON "comment"("snippetId", "authorId");
+
+-- CreateIndex
+CREATE INDEX "comment_like_userId_idx" ON "comment_like"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "comment_like_commentId_userId_key" ON "comment_like"("commentId", "userId");
+
+-- CreateIndex
+CREATE INDEX "snippet_star_userId_idx" ON "snippet_star"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "snippet_star_userId_snippetId_key" ON "snippet_star"("userId", "snippetId");
+
+-- AddForeignKey
+ALTER TABLE "workspace" ADD CONSTRAINT "workspace_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "folder" ADD CONSTRAINT "folder_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "folder" ADD CONSTRAINT "folder_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Snippet" ADD CONSTRAINT "Snippet_folderId_fkey" FOREIGN KEY ("folderId") REFERENCES "folder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Snippet" ADD CONSTRAINT "Snippet_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Snippet" ADD CONSTRAINT "Snippet_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comment" ADD CONSTRAINT "comment_snippetId_fkey" FOREIGN KEY ("snippetId") REFERENCES "Snippet"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comment" ADD CONSTRAINT "comment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comment_like" ADD CONSTRAINT "comment_like_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "comment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comment_like" ADD CONSTRAINT "comment_like_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "snippet_star" ADD CONSTRAINT "snippet_star_snippetId_fkey" FOREIGN KEY ("snippetId") REFERENCES "Snippet"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "snippet_star" ADD CONSTRAINT "snippet_star_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,13 @@ model User {
   sessions      Session[]
   accounts      Account[]
 
+  workspaces   Workspace[]
+  folders      Folder[]
+  snippets     Snippet[]
+  comments     Comment[]
+  commentLikes CommentLike[]
+  stars        SnippetStar[]
+
   @@unique([email])
   @@map("user")
 }
@@ -71,4 +78,128 @@ model Verification {
   updatedAt  DateTime?
 
   @@map("verification")
+}
+
+model Workspace {
+  id          String  @id @default(cuid())
+  name        String
+  description String?
+  slug        String  @unique
+
+  // relations
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  folders  Folder[]
+  snippets Snippet[]
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([userId, name]) // unique workspace name for each user
+  @@map("workspace")
+}
+
+model Folder {
+  id          String  @id @default(cuid())
+  name        String
+  description String?
+
+  // relations
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  workspaceId String
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  snippets Snippet[]
+
+  // metadata
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([workspaceId, userId, name]) // unique folder name for each workspace and user
+  @@map("folder")
+}
+
+model Snippet {
+  id          String  @id @default(cuid())
+  name        String
+  description String?
+  code        String
+  public      Boolean @default(true) // by default all snips are public
+
+  // relations
+  folderId String
+  folder   Folder @relation(fields: [folderId], references: [id], onDelete: Cascade)
+
+  workspaceId String
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  comments Comment[]
+  stars    SnippetStar[]
+
+  // counts
+  startCount Int @default(0) // denormalize from SnippetStar table => number of rows in SnippetStar
+  commentCount Int @default(0) // denormalize from SnippetStar table => number of rows in Comments tables
+
+  // timestamps
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  // expiresAt DateTime : TODO : add this field to keep expiry of 24hrs, 7 days, 30 days.
+}
+
+model Comment {
+  id      String @id @default(cuid())
+  content String
+
+  snippetId String
+  snippet   Snippet @relation(fields: [snippetId], references: [id], onDelete: Cascade)
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  likes CommentLike[]
+
+  // metadata
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("comment")
+}
+
+model CommentLike {
+  id String @id @default(cuid())
+
+  commentId String
+  comment   Comment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // metadata
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([commentId, userId]) // a user can like a comment only once
+  @@map("comment_like")
+}
+
+model SnippetStar {
+  id String @id @default(cuid())
+
+  snippetId String
+  snippet   Snippet @relation(fields: [snippetId], references: [id], onDelete: Cascade)
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([userId,snippetId]) // a user can star only once
+  @@map("snippet_star")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,8 +89,8 @@ model Workspace {
   slug        String  @unique
 
   // relations
-  userId String
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  ownerId String
+  owner   User   @relation(fields: [ownerId], references: [id], onDelete: Cascade)
 
   folders  Folder[]
   snippets Snippet[]
@@ -98,8 +98,9 @@ model Workspace {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  @@unique([userId, name]) // unique workspace name for each user
+  @@unique([ownerId, name]) // unique workspace name for each user
   @@map("workspace")
+  @@index([ownerId])
 }
 
 model Folder {
@@ -108,8 +109,8 @@ model Folder {
   description String?
 
   // relations
-  userId String
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  ownerId String
+  owner   User   @relation(fields: [ownerId], references: [id], onDelete: Cascade)
 
   workspaceId String
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
@@ -120,13 +121,14 @@ model Folder {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  @@unique([workspaceId, userId, name]) // unique folder name for each workspace and user
+  @@unique([workspaceId, ownerId, name]) // unique folder name for each workspace and user
   @@map("folder")
+  @@index([ownerId])
 }
 
 model Snippet {
   id          String  @id @default(cuid())
-  name        String
+  name        String  
   description String?
   code        String
   public      Boolean @default(true) // by default all snips are public
@@ -138,20 +140,23 @@ model Snippet {
   workspaceId String
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
-  userId String
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  authorId String
+  author   User   @relation(fields: [authorId], references: [id], onDelete: Cascade)
 
   comments Comment[]
   stars    SnippetStar[]
 
   // counts
   startCount Int @default(0) // denormalize from SnippetStar table => number of rows in SnippetStar
-  commentCount Int @default(0) // denormalize from SnippetStar table => number of rows in Comments tables
+  commentCount Int @default(0) // denormalize from Comment table => number of rows in Comments tables
 
-  // timestamps
+  // metadata
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
   // expiresAt DateTime : TODO : add this field to keep expiry of 24hrs, 7 days, 30 days.
+
+  @@unique([folderId,name]) // two snips can't have same name inside a folder
+  @@index([authorId,folderId,workspaceId])
 }
 
 model Comment {
@@ -161,8 +166,8 @@ model Comment {
   snippetId String
   snippet   Snippet @relation(fields: [snippetId], references: [id], onDelete: Cascade)
 
-  userId String
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  authorId String
+  author   User   @relation(fields: [authorId], references: [id], onDelete: Cascade)
 
   likes CommentLike[]
 
@@ -171,6 +176,7 @@ model Comment {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("comment")
+  @@index([snippetId,authorId])
 }
 
 model CommentLike {
@@ -188,6 +194,7 @@ model CommentLike {
 
   @@unique([commentId, userId]) // a user can like a comment only once
   @@map("comment_like")
+  @@index([userId])
 }
 
 model SnippetStar {
@@ -204,4 +211,5 @@ model SnippetStar {
 
   @@unique([userId,snippetId]) // a user can star only once
   @@map("snippet_star")
+  @@index([userId])
 }


### PR DESCRIPTION
# Proposed Changes
- Fixes #2 

This PR introduces the database schema and performs prisma migration without any existing data loss.

The following models have been created - 
1. `Workspace` - for storing workspaces of a user
2. `Folder` - for storing folders within a workspace
3. `Snippet` - for storing snips of a user within a folder
4. `Comment` - for storing comments on a snip
5. `CommentLike` - for storing likes on a comment
6. `SnippetStar` - for storing stars on a snippet

- The database has also been denormalized on purpose by adding `userId` as FK in `Folder` and `Snippet` models to cross-query from both tables.

- Additionaly `commentCount` and `startCount` in `Snippet` model has been kept on purpose violating the "Single source of truth" principle to avoid joins in query for each snippet when required to show number of comments and number of stars. 
-  This comes with the tradeoff of having to update relevant tables for CRUD operations.
