### PR TITLE
feat: create session validator for API routes and create a /me route and use swr to fetch API on client side

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,0 +1,8 @@
+import { withSession } from "@/lib/api/with-session";
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = async (req: NextRequest): Promise<NextResponse> => {
+  return await withSession(req, async ({user}) => {
+    return NextResponse.json({user});
+  });
+};

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,18 +1,20 @@
+import { UserCard } from "@/components/user-card";
 import { auth } from "@/lib/auth"
 import { headers } from "next/headers";
-import { redirect } from "next/navigation";
+// import { redirect } from "next/navigation";
 
 export default async function Dashboard() {
   const session = await auth.api.getSession({
     headers : await headers()
   });
 
-  if(!session){
-    redirect("/")
-  }
+  // if(!session){
+  //   redirect("/")
+  // }
 
   return <div className="container">
     <h1>Dashboard</h1>
     <pre>{JSON.stringify(session,null,2)}</pre>
+    <UserCard/>
   </div>
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -11,7 +11,7 @@ export default async function Dashboard() {
     redirect("/")
   }
 
-  return <div>
+  return <div className="container">
     <h1>Dashboard</h1>
     <pre>{JSON.stringify(session,null,2)}</pre>
   </div>

--- a/components/user-card.tsx
+++ b/components/user-card.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useUser } from "@/swr/use-user";
+
+export const UserCard = () => {
+
+  const {data,isLoading,error} = useUser();
+
+  return (
+    <div>
+      {isLoading ? (
+        <p>{"Fetching user details...."}</p>
+      ) : (
+        <pre>
+          {error && JSON.stringify(error,null,2)}
+          {data && JSON.stringify(data,null,2)}
+        </pre>
+      )}
+    </div>
+  );
+};

--- a/lib/api/error-handler.ts
+++ b/lib/api/error-handler.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SpoolAPIError } from "./error";
+
+export const spoolAPIErrorHandler = (req : NextRequest, err : SpoolAPIError)=>{
+  console.log(`Error on: ${req.url}\tmethod: ${req.method}`);
+  console.log(err);
+  return NextResponse.json({
+    error : {
+      status : err.status,
+      message : err.message,
+    }
+  })
+}
+
+export const spoolInternalAPIErrorHandler = (req : NextRequest, err : Error | unknown, message ?:string)=>{
+  console.info(`Error on: ${req.url}\tmethod: ${req.method}`);
+  console.error(err);
+  const defaultError = "Oops, internal server error!";
+  return NextResponse.json({
+    error : {
+      status : "internal_server_error",
+      message : message ? message : defaultError,
+    }
+  })
+}

--- a/lib/api/error.ts
+++ b/lib/api/error.ts
@@ -1,0 +1,26 @@
+import {z} from "zod"
+
+export const ZAPIErrorStatusSchema = z.enum([
+  "bad_request",
+  "not_found",
+  "internal_server_error",
+  "unauthorized",
+  "forbidden",
+  "rate_limit_exceeded",
+  "invite_expired",
+  "invite_pending",
+  "exceeded_limit",
+  "conflict",
+  "unprocessable_entity",
+])
+
+export type TAPIErrorStatus = z.infer<typeof ZAPIErrorStatusSchema>;
+
+export class SpoolAPIError extends Error {
+  public readonly status : TAPIErrorStatus;
+
+  constructor({status,message} : {status : TAPIErrorStatus, message : string}){
+    super(message);
+    this.status = status;
+  }
+}

--- a/lib/api/with-session.ts
+++ b/lib/api/with-session.ts
@@ -1,0 +1,31 @@
+import { } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "../auth";
+import {User, Session,} from "better-auth"
+
+type TSessionRouteHandler = ({
+  user,
+  session,
+}: {
+  user: User;
+  session: Session;
+}) => Promise<NextResponse>;
+
+export const withSession = async (
+  req: NextRequest,
+  handler: TSessionRouteHandler
+): Promise<NextResponse> => {
+  try {
+    const session = await auth.api.getSession({headers : req.headers});
+    if(!session){
+      throw new Error("no session")
+    }
+    return await handler({session : session.session, user : session.user});
+  } catch (e) {
+    console.error("Error in withSession:", e);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+};

--- a/lib/api/with-session.ts
+++ b/lib/api/with-session.ts
@@ -2,6 +2,8 @@ import { } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "../auth";
 import {User, Session,} from "better-auth"
+import { SpoolAPIError } from "./error";
+import { spoolAPIErrorHandler, spoolInternalAPIErrorHandler } from "./error-handler";
 
 type TSessionRouteHandler = ({
   user,
@@ -16,16 +18,24 @@ export const withSession = async (
   handler: TSessionRouteHandler
 ): Promise<NextResponse> => {
   try {
+    if(!req.headers.get("Cookie")){
+      throw new SpoolAPIError({
+        status : "bad_request",
+        message : "Missing authorization header. Please add auth token in Cookie header."
+      })
+    }
     const session = await auth.api.getSession({headers : req.headers});
     if(!session){
-      throw new Error("no session")
+      throw new SpoolAPIError({
+        status : "unauthorized",
+        message : "Invalid or incorrect auth token in request header."
+      })
     }
     return await handler({session : session.session, user : session.user});
-  } catch (e) {
-    console.error("Error in withSession:", e);
-    return NextResponse.json(
-      { error: "Internal Server Error" },
-      { status: 500 }
-    );
+  } catch (error) {
+    if(error instanceof SpoolAPIError){
+      return spoolAPIErrorHandler(req,error);
+    }
+    return spoolInternalAPIErrorHandler(req,error);
   }
 };

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -14,10 +14,12 @@ const generateUsername = (format: string) => {
 
 export const auth = betterAuth({
   appName: "Spool",
-
   database: prismaAdapter(prisma, {
     provider: "postgresql",
   }),
+  advanced : {
+    cookiePrefix : "spool",
+  },
   session: {
     expiresIn: 60 * 60 * 24 * 7, // 7 days
     updateAge: 60 * 60 * 24, // update active session every 1 day

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.2",
     "sonner": "^2.0.3",
+    "swr": "^2.3.3",
     "tailwind-merge": "^3.2.0",
     "zod": "^3.24.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       sonner:
         specifier: ^2.0.3
         version: 2.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      swr:
+        specifier: ^2.3.3
+        version: 2.3.3(react@19.1.0)
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1377,6 +1380,10 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
@@ -2367,6 +2374,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.3.3:
+    resolution: {integrity: sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tailwind-merge@3.2.0:
     resolution: {integrity: sha512-FQT/OVqCD+7edmmJpsgCsY820RTD5AkBryuG5IUqR5YQZSdj5xlH5nLgH7YPths7WsLPSpSBNneJdM8aS8aeFA==}
 
@@ -2460,6 +2472,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3661,6 +3678,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.0.4: {}
 
   detect-node-es@1.1.0: {}
@@ -4860,6 +4879,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.3.3(react@19.1.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
+
   tailwind-merge@3.2.0: {}
 
   tailwindcss@4.1.5: {}
@@ -4980,6 +5005,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.2
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/swr/use-user.tsx
+++ b/swr/use-user.tsx
@@ -1,0 +1,16 @@
+"use client";
+import useSWR from "swr";
+
+export const useUser = ()=>{
+
+  const { isLoading, error, data } = useSWR("/api/me", (...args) =>
+    fetch(...args).then((res) => res.json())
+  );
+  
+  // TODO : return the component that renders data directly from the hook to be reused throughout the app
+  return {
+    isLoading,
+    error,
+    data
+  }
+}


### PR DESCRIPTION
## Proposed Changes
- Fixes #6 

- This PR introduces a `withSession()` API validator, that will act as a custom validator for API routes that are only accessible by authenticated users.
- Create API endpoint, GET /api/me - returns details of authenticated user.
- Extended built-in `Error` class with `SpoolAPIError`.
- Create route handlers for `SpoolAPIError` and `Error` classes.
- Used swr lib to create hook `useUser` that fetches the `/api/me` route.

Refer to [swr example](https://swr.vercel.app/docs/getting-started#example) to understand data fetching patterns using SWR.
