### PR TITLE
feat : create default workspace and folder for new users and redirect to workspace

### DIFF
--- a/app/[username]/[slug]/[folderSlug]/page.tsx
+++ b/app/[username]/[slug]/[folderSlug]/page.tsx
@@ -1,0 +1,14 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ username: "string"; slug: "string"; folderSlug: "string" }>;
+}) {
+  const {username,slug,folderSlug} = await params;
+  // validations for auth, workspace permission and folder permissions
+  return (
+    <div className="container">
+      <p>{username} / {slug} / {folderSlug}</p>
+    </div>
+  )
+}
+

--- a/app/[username]/[slug]/page.tsx
+++ b/app/[username]/[slug]/page.tsx
@@ -1,0 +1,17 @@
+// @Param slug - workspace slug
+export default async function Page({params} : {params : Promise<{
+  username : "string",
+  slug : "string"
+}>}){
+  const {username,slug} = await params;
+
+  // check if the user is auth?
+  // check if user is the owner of workspace
+
+  return(
+    <div className="container">
+      <p>{username}</p>
+      <p>{slug}</p>
+    </div>
+  )
+}

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -1,0 +1,34 @@
+import { SpoolAPIError } from "@/lib/api/error";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+
+  const session = await auth.api.getSession({
+    headers : await headers()
+  })
+
+  if(!session){
+    redirect("/");
+  }
+
+  if(session.user.username != username){
+    // unauthorized
+    throw new SpoolAPIError({
+      status : "unauthorized",
+      message : "Access to requested resource is denied"
+    })
+  }
+
+  // TODO : show user's workspaces here
+  return <div className="container">
+    <p>{username}</p>
+    <pre>{JSON.stringify(session,null,2)}</pre>
+  </div>;
+}

--- a/app/api/folders/route.ts
+++ b/app/api/folders/route.ts
@@ -1,0 +1,69 @@
+import { SpoolAPIError } from "@/lib/api/error";
+import {
+  spoolAPIErrorHandler,
+  spoolInternalAPIErrorHandler,
+} from "@/lib/api/error-handler";
+import { withWorkspace } from "@/lib/api/with-workspace";
+import { prisma } from "@/lib/prisma";
+import { ZCreateFolderSchema } from "@/lib/zod";
+import { Prisma } from "@prisma/client";
+import slugify from "@sindresorhus/slugify";
+import { NextRequest, NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+// /api/folders/?slug=<workspace-slug>
+export const POST = (req: NextRequest) => {
+  return withWorkspace(req, async ({ user, workspace }) => {
+    try {
+      const { name, description } = await ZCreateFolderSchema.parseAsync(
+        await req.json()
+      );
+       
+      const nameAlreadyUsed = await prisma.folder.findFirst({
+        where : {
+          name,
+          workspaceId : workspace.id,
+          ownerId : user.id
+        }
+      })
+      if(nameAlreadyUsed){
+        throw new SpoolAPIError({
+          status : "conflict",
+          message : "A folder with same name already exists in the workspace"
+        })
+      }
+      const folder = await prisma.folder.create({
+        data: {
+          name,
+          slug: slugify(name),
+          description,
+          ownerId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
+
+      return NextResponse.json(
+        {
+          data: folder,
+          message: "Folder created successfully",
+        },
+        {
+          status: 201,
+        }
+      );
+    } catch (error) {
+      console.error(error);
+      if (error instanceof ZodError) {
+        return NextResponse.json({ error: error.flatten() });
+      } else if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        return NextResponse.json(
+          { error: "database_error", details: error.message },
+          { status: 500 }
+        );
+      } else if (error instanceof SpoolAPIError) {
+        return spoolAPIErrorHandler(req, error);
+      }
+      return spoolInternalAPIErrorHandler(req, error);
+    }
+  });
+};

--- a/app/api/workspaces/route.ts
+++ b/app/api/workspaces/route.ts
@@ -19,18 +19,18 @@ export const POST = async (req: NextRequest) => {
       // Trade-off : currently API is used internally, that means it will be called by me
       // so I will make sure to check if a workspace exists before calling this API. 
       // Hence commenting out for now!
-      // const slugAlreadyUsed = await prisma.workspace.findFirst({
-      //   where : {
-      //     slug,
-      //   }
-      // })
+      const slugAlreadyUsed = await prisma.workspace.findFirst({
+        where : {
+          slug,
+        }
+      })
 
-      // if(slugAlreadyUsed){
-      //   throw new SpoolAPIError({
-      //     status : "conflict",
-      //     message : `The slug \"${slug}\" is already in use.`
-      //   })
-      // }
+      if(slugAlreadyUsed){
+        throw new SpoolAPIError({
+          status : "conflict",
+          message : `The slug \"${slug}\" is already in use.`
+        })
+      }
 
       // create new workspace
       const workspace = await prisma.workspace.create({
@@ -41,7 +41,7 @@ export const POST = async (req: NextRequest) => {
           slug,
         },
       });
-      return NextResponse.json({ data: workspace });
+      return NextResponse.json({ data: workspace, message : "Workspace created successfully!" });
     } catch (err) {
       if (err instanceof ZodError) {
         console.error(err);

--- a/app/api/workspaces/route.ts
+++ b/app/api/workspaces/route.ts
@@ -1,0 +1,60 @@
+import { SpoolAPIError } from "@/lib/api/error";
+import { spoolAPIErrorHandler, spoolInternalAPIErrorHandler } from "@/lib/api/error-handler";
+import { withSession } from "@/lib/api/with-session";
+import { prisma } from "@/lib/prisma";
+import { ZCreateWorkspaceSchema } from "@/lib/zod";
+import { Prisma } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+// POST /api/workspaces - create a new workspace
+export const POST = async (req: NextRequest) => {
+  return withSession(req, async ({ user }) => {
+    try {
+      const { name, description, slug } =
+        await ZCreateWorkspaceSchema.parseAsync(await req.json());
+
+      // check if workspace exists with the same slug
+      // this really scans the all the rows in workspace table, which won't be really good for performance!
+      // Trade-off : currently API is used internally, that means it will be called by me
+      // so I will make sure to check if a workspace exists before calling this API. 
+      // Hence commenting out for now!
+      // const slugAlreadyUsed = await prisma.workspace.findFirst({
+      //   where : {
+      //     slug,
+      //   }
+      // })
+
+      // if(slugAlreadyUsed){
+      //   throw new SpoolAPIError({
+      //     status : "conflict",
+      //     message : `The slug \"${slug}\" is already in use.`
+      //   })
+      // }
+
+      // create new workspace
+      const workspace = await prisma.workspace.create({
+        data: {
+          ownerId: user.id,
+          name,
+          description,
+          slug,
+        },
+      });
+      return NextResponse.json({ data: workspace });
+    } catch (err) {
+      if (err instanceof ZodError) {
+        console.error(err);
+        return NextResponse.json({ error: err.flatten() });
+      } else if (err instanceof Prisma.PrismaClientKnownRequestError) {
+        return NextResponse.json(
+          { error: "database_error", details: err.message },
+          { status: 500 }
+        );
+      }else if(err instanceof SpoolAPIError){
+        return spoolAPIErrorHandler(req,err);
+      }
+      return spoolInternalAPIErrorHandler(req, err);
+    }
+  });
+};

--- a/app/email-verified/page.tsx
+++ b/app/email-verified/page.tsx
@@ -1,3 +1,0 @@
-export default function Page(){
-  return <div>You are verified</div>
-}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,7 +2,7 @@ import { LoginCard } from "../../components/auth/login-card";
 
 export default function LoginPage() {
   return (
-    <div className="container-wrapper md:min-h-[92vh] flex justify-center items-center">
+    <div className="container-wrapper min-h-[80vh] md:min-h-[92vh] flex justify-center items-center">
       <LoginCard/>
     </div>
   );

--- a/app/onboard/default-workspace.tsx
+++ b/app/onboard/default-workspace.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import slugify from "@sindresorhus/slugify";
+import { Session } from "better-auth";
+import { User } from "@prisma/client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { LoadingCircle } from "@/components/icons/loading-circle";
+
+export const CreateDefaultWorkspace = ({
+  session,
+  user,
+}: {
+  session: Session;
+  user: User;
+}) => {
+  const router = useRouter();
+  const [status, setStatus] = useState<
+    "idle" | "creating" | "error" | "redirecting"
+  >("idle");
+
+  const createDefaultWorkspaceAndFolder = async () => {
+    try {
+      setStatus("creating");
+
+      const slug = slugify(
+        `playground-${Math.floor(Math.random() * 10000) + 1}`
+      );
+
+      const workspaceRes = await fetch("/api/workspaces", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `spool.session_token=${session.token}`,
+        },
+        body: JSON.stringify({
+          name: "Playground",
+          slug,
+          description: "The default workspace of a user",
+        }),
+      });
+
+      if (!workspaceRes.ok) throw new Error("Failed to create workspace");
+
+      const { data: workspace } = await workspaceRes.json();
+
+      const folderRes = await fetch(
+        `/api/folders?workspace-slug=${workspace.slug}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `spool.session_token=${session.token}`,
+          },
+          body: JSON.stringify({
+            name: "Hobby",
+            description: "Folder for my cool snips",
+          }),
+        }
+      );
+
+      if (!folderRes.ok) throw new Error("Failed to create folder");
+
+      const { data: folder } = await folderRes.json();
+
+      setStatus("redirecting");
+      router.push(`/${user.username}/${workspace.slug}/${folder.name}`);
+    } catch (error) {
+      console.error("Workspace creation error:", error);
+      setStatus("error");
+      router.refresh(); // retry in case of error
+    }
+  };
+
+  useEffect(() => {
+    if (status === "idle") {
+      createDefaultWorkspaceAndFolder();
+    }
+  }, [status]);
+
+  return (
+    <div className="container-wrapper min-h-[80vh] md:min-h-[92vh] flex justify-center items-center flex-col gap-4 text-center">
+      {status === "creating" && (
+        <div className="flex justify-start items-center gap-4 md:text-xl">
+          <LoadingCircle />
+          <p>Setting up your workspace...</p>
+        </div>
+      )}
+      {status === "redirecting" && (
+        <div className="flex justify-start items-center gap-4 md:text-xl">
+          <LoadingCircle />
+          <p>Redirecting you to your default folder...</p>
+        </div>
+      )}
+      {status === "error" && (
+        <p className="text-red-500">An error occurred. Retrying...</p>
+      )}
+    </div>
+  );
+};

--- a/app/onboard/default-workspace.tsx
+++ b/app/onboard/default-workspace.tsx
@@ -81,13 +81,13 @@ export const CreateDefaultWorkspace = ({
   return (
     <div className="container-wrapper min-h-[80vh] md:min-h-[92vh] flex justify-center items-center flex-col gap-4 text-center">
       {status === "creating" && (
-        <div className="flex justify-start items-center gap-4 md:text-xl">
+        <div className="flex justify-start items-center gap-4">
           <LoadingCircle />
           <p>Setting up your workspace...</p>
         </div>
       )}
       {status === "redirecting" && (
-        <div className="flex justify-start items-center gap-4 md:text-xl">
+        <div className="flex justify-start items-center gap-4">
           <LoadingCircle />
           <p>Redirecting you to your default folder...</p>
         </div>

--- a/app/onboard/page.tsx
+++ b/app/onboard/page.tsx
@@ -1,0 +1,59 @@
+/* onboard page with the following purpose:
+1. users will land here after verifying their email address upon signing up with credentials
+2. a default workspace and default folder will be created for the user
+3. progress states for the above actions will be shown here
+4. upon creation of these resources, user should be redirected to /<username>/<workspace-slug>/<folder-slug>
+
+Validations:
+1. unauthenticated users should be redirected to `/login`
+2. authenticated users which don't have any workspace should only be allowed to be here!
+3. authenticated users with greater than or equal to 1 workspaces should be redirected to /<username>
+*/
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { headers } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+import { CreateDefaultWorkspace } from "./default-workspace";
+
+
+// type TSearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
+
+export default async function Page() {
+  const session = await auth.api.getSession({
+    headers : await headers()
+  })
+
+  if(!session){
+    // unauthenticated users not allowed
+    redirect("/")
+  }
+
+  const workspaceCount = await prisma.workspace.count({
+    where : {
+      ownerId : session.user.id
+    }
+  })
+
+  if(workspaceCount > 0){
+    // if not first time user
+    redirect(`/${session.user.username}`)
+  }
+
+  const user = await prisma.user.findUnique({
+    where : {
+      id: session.user.id
+    }
+  })
+
+  if(!user){
+    return notFound();
+  }
+
+  return (
+    <div className="container">
+      <div>Email verified</div>
+      <CreateDefaultWorkspace session={session.session} user={user}/>
+    </div>
+  );
+}

--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -1,9 +1,7 @@
-import { SignupCard } from "@/components/auth/signup-card";
-
-export default function SignUp() {
+export default function Page(){
   return (
     <div className="container-wrapper min-h-[80vh] md:min-h-[92vh] flex justify-center items-center">
-      <SignupCard />
+        Please check your email for magic link
     </div>
-  );
+  )
 }

--- a/components/auth/login-email-form.tsx
+++ b/components/auth/login-email-form.tsx
@@ -40,7 +40,6 @@ const formSchema = z.object({
 type FormSchemaType = z.infer<typeof formSchema>;
 
 export const LoginWithEmailForm = () => {
-  const router = useRouter();
 
   const form = useForm<FormSchemaType>({
     defaultValues: {
@@ -55,6 +54,7 @@ export const LoginWithEmailForm = () => {
       {
         email,
         password,
+        callbackURL : "/onboard"
       },
       {
         onError: (ctx) => {
@@ -62,7 +62,7 @@ export const LoginWithEmailForm = () => {
         },
         onSuccess : ()=>{
           toast.success("Logged in successfully");
-          router.push("/dashboard")
+          // router.push("/onboard")
         }
       }
     );

--- a/components/auth/login-email-form.tsx
+++ b/components/auth/login-email-form.tsx
@@ -15,7 +15,6 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { authClient } from "@/lib/auth-client";
 import { toast } from "sonner";
-import { useRouter } from "next/navigation";
 import { LoadingCircle } from "../icons/loading-circle";
 
 const formSchema = z.object({
@@ -54,7 +53,6 @@ export const LoginWithEmailForm = () => {
       {
         email,
         password,
-        callbackURL : "/onboard"
       },
       {
         onError: (ctx) => {

--- a/components/auth/login-github-form.tsx
+++ b/components/auth/login-github-form.tsx
@@ -23,9 +23,8 @@ export const LoginWithGitHubForm = () => {
     await authClient.signIn.social(
       {
         provider: "github",
-        callbackURL: "/dashboard", // TODO : use env for dev and prod base URL
-        // newUserCallbackURL : use this for creating workspace and projects for new user
-        // errorCallbackURL : create a error page?
+        callbackURL: "/onboard", 
+        newUserCallbackURL : "/onboard"
       },
       {
         onRequest: () => {

--- a/components/auth/login-username-form.tsx
+++ b/components/auth/login-username-form.tsx
@@ -78,7 +78,7 @@ export const LoginWithUsernameForm = () => {
         },
         onSuccess : ()=>{
           toast.success("Logged in successfully");
-          router.push("/dashboard")
+          router.push("/onboard")
         }
       }
     );

--- a/components/auth/signup-email-form.tsx
+++ b/components/auth/signup-email-form.tsx
@@ -16,7 +16,6 @@ import { LoadingCircle } from "../icons/loading-circle";
 import { Input } from "../ui/input";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
-import { useRouter } from "next/navigation";
 
 const formSchema = z.object({
   email: z.string().email({ message: "Please use a valid email address" }),
@@ -58,7 +57,6 @@ const formSchema = z.object({
 type FormSchemaType = z.infer<typeof formSchema>;
 
 export const SignupEmailForm = () => {
-  const router = useRouter();
 
   const form = useForm<FormSchemaType>({
     defaultValues: {
@@ -71,12 +69,12 @@ export const SignupEmailForm = () => {
   });
 
   async function onSubmit({ name, username,email, password }: FormSchemaType) {
-    await authClient.signUp.email(
+    const {error} = await authClient.signUp.email(
       {
         name,
         email,
         password,
-        username
+        username,
       },
       {
         onError: (ctx) => {
@@ -84,10 +82,16 @@ export const SignupEmailForm = () => {
         },
         onSuccess: () => {
           toast.success("Please check your email for verification link");
-          router.push("/dashboard");
+          // TODO : create a /verify-email page to show users that they have to open email 
+          // verification using magic-link
         },
       }
     );
+
+    if(error){
+      toast.error(error.message)
+      return;
+    }
   }
 
   return (

--- a/lib/api/with-workspace.ts
+++ b/lib/api/with-workspace.ts
@@ -17,7 +17,7 @@ type TWorkspaceRouteHandler = ({
   user: User;
   session: Session;
   workspace: Workspace;
-}) => Promise<NextRequest>;
+}) => Promise<NextResponse>;
 
 export const withWorkspace = async (
   req: NextRequest,
@@ -40,7 +40,7 @@ export const withWorkspace = async (
     }
 
     // const workspaceSlug = req.url
-    const workspaceSlug = req.nextUrl.searchParams.get("slug");
+    const workspaceSlug = req.nextUrl.searchParams.get("workspace-slug");
     if (!workspaceSlug) {
       throw new SpoolAPIError({
         status: "bad_request",

--- a/lib/api/with-workspace.ts
+++ b/lib/api/with-workspace.ts
@@ -1,0 +1,89 @@
+import { Prisma, Workspace } from "@prisma/client";
+import { User, Session } from "better-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { SpoolAPIError } from "./error";
+import { auth } from "../auth";
+import {
+  spoolAPIErrorHandler,
+  spoolInternalAPIErrorHandler,
+} from "./error-handler";
+import { prisma } from "../prisma";
+
+type TWorkspaceRouteHandler = ({
+  user,
+  session,
+  workspace,
+}: {
+  user: User;
+  session: Session;
+  workspace: Workspace;
+}) => Promise<NextRequest>;
+
+export const withWorkspace = async (
+  req: NextRequest,
+  handler: TWorkspaceRouteHandler
+) => {
+  try {
+    if (!req.headers.get("Cookie")) {
+      throw new SpoolAPIError({
+        status: "bad_request",
+        message:
+          "Missing authorization header. Please add auth token in Cookie header.",
+      });
+    }
+    const session = await auth.api.getSession({ headers: req.headers });
+    if (!session) {
+      throw new SpoolAPIError({
+        status: "unauthorized",
+        message: "Invalid or incorrect auth token in request header.",
+      });
+    }
+
+    // const workspaceSlug = req.url
+    const workspaceSlug = req.nextUrl.searchParams.get("slug");
+    if (!workspaceSlug) {
+      throw new SpoolAPIError({
+        status: "bad_request",
+        message:
+          "Missing workspace slug. Please add workspace slug in search params",
+      });
+    }
+
+    const workspace = await prisma.workspace.findUnique({
+      where: {
+        slug: workspaceSlug,
+      },
+    });
+
+    if (!workspace) {
+      throw new SpoolAPIError({
+        status: "not_found",
+        message: "Workspace associated with provided slug not found",
+      });
+    }
+
+    if (workspace.ownerId != session.user.id) {
+      throw new SpoolAPIError({
+        status: "forbidden",
+        message: "The permission to access requested workspace is denied",
+      });
+    }
+
+    return await handler({
+      user: session.user,
+      session: session.session,
+      workspace,
+    });
+  } catch (error) {
+    if (error instanceof SpoolAPIError) {
+      return spoolAPIErrorHandler(req, error);
+    }
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      return NextResponse.json(
+        { error: "database_error", details: error.message },
+        { status: 500 }
+      );
+    }
+    return spoolInternalAPIErrorHandler(req, error);
+  }
+};

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -50,7 +50,7 @@ export const auth = betterAuth({
   },
   emailVerification: {
     sendOnSignUp: true,
-    autoSignInAfterVerification: true,
+    autoSignInAfterVerification: true,    
     expiresIn: 60 * 60, // 1 hour
     sendVerificationEmail: async ({ user, token }) => {
       const verificationUrl = `${process.env.BETTER_AUTH_URL}/api/auth/verify-email?token=${token}&callbackURL=${process.env.EMAIL_VERIFICATION_CALLBACK_URL}`;

--- a/lib/zod.ts
+++ b/lib/zod.ts
@@ -3,6 +3,19 @@ import { z } from "zod";
 
 const validSlugRegex = new RegExp(/^[a-zA-Z0-9\-]+$/);
 
+/*
+Valid : 
+myfile.txt
+report_final2025.csv
+backup-01.tar.gz
+
+Invalid :
+my file.txt
+data\n.txt
+notes\tfinal.md
+*/
+export const isValidFilename = /^[^<>:"/\\|?*\x00-\x1F\s]+$/;
+
 export const ZCreateWorkspaceSchema = z.object({
   name: z
     .string()
@@ -18,4 +31,22 @@ export const ZCreateWorkspaceSchema = z.object({
       message:
         "Slugs can only contain letters, numbers, and hyphens. No spaces or special characters are allowed",
     }),
+});
+
+export const ZCreateFolderSchema = z.object({
+  name: z
+    .string()
+    .min(1, { message: "Name is required" })
+    .max(50, { message: "Name must be less than 50 characters" })
+    .refine(
+      (val) =>
+        /^[^<>:"/\\|?*\x00-\x1F\s.][^<>:"/\\|?*\x00-\x1F\s]*[^<>:"/\\|?*\x00-\x1F\s.]$/.test(
+          val
+        ),
+      {
+        message:
+          'Folder name can not contain spaces or characters like < > : " / \\ | ? * and should not start or end with a dot or space.',
+      }
+    ),
+  description: z.string().optional(),
 });

--- a/lib/zod.ts
+++ b/lib/zod.ts
@@ -1,0 +1,21 @@
+import slugify from "@sindresorhus/slugify";
+import { z } from "zod";
+
+const validSlugRegex = new RegExp(/^[a-zA-Z0-9\-]+$/);
+
+export const ZCreateWorkspaceSchema = z.object({
+  name: z
+    .string()
+    .min(1, { message: "Name is required" })
+    .max(30, { message: "Name should be less than 30 characters" }),
+  description: z.string().optional(),
+  slug: z
+    .string()
+    .min(5, { message: "Slug must be at least 3 characters" })
+    .max(48, { message: "Slug must be less than 48 characters" })
+    .transform((v) => slugify(v))
+    .refine((v) => validSlugRegex.test(v), {
+      message:
+        "Slugs can only contain letters, numbers, and hyphens. No spaces or special characters are allowed",
+    }),
+});

--- a/prisma/migrations/20250509143632_add_slug_for_folders_and_index_fk/migration.sql
+++ b/prisma/migrations/20250509143632_add_slug_for_folders_and_index_fk/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[workspaceId,slug]` on the table `folder` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `slug` to the `folder` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX "folder_ownerId_idx";
+
+-- DropIndex
+DROP INDEX "folder_workspaceId_ownerId_name_key";
+
+-- AlterTable
+ALTER TABLE "folder" ADD COLUMN     "slug" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "folder_ownerId_workspaceId_idx" ON "folder"("ownerId", "workspaceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "folder_workspaceId_slug_key" ON "folder"("workspaceId", "slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,7 @@ model Workspace {
 model Folder {
   id          String  @id @default(cuid())
   name        String
+  slug        String
   description String?
 
   // relations
@@ -121,9 +122,9 @@ model Folder {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  @@unique([workspaceId, ownerId, name]) // unique folder name for each workspace and user
+  @@unique([workspaceId, slug]) // unique folder slug for each workspace and user
   @@map("folder")
-  @@index([ownerId])
+  @@index([ownerId,workspaceId])
 }
 
 model Snippet {


### PR DESCRIPTION
## Proposed Changes
- Fixes #8 

1. Upon authentication, users are redirected to `/onboard` page, where if the user doesn't have any workspace, we create a default workspace and fodler for the user and redirect to `/<username>/<slug>/<folderSlug>`
2. Created pages `/<username>`, `/<username>/<slug>` and `/<username>/<slug>/<folderSlug>`
3. Depricated pages `/email-verified` and `/dashboard`.

This completes the authentication flow to larger extent. Only bug fixes, email verification page and UI is left. 