### PR TITLE
feat : update POST `/api/folders` route

### DIFF
--- a/app/api/folders/route.ts
+++ b/app/api/folders/route.ts
@@ -64,7 +64,7 @@ export const GET = (req: NextRequest) => {
 export const POST = (req: NextRequest) => {
   return withWorkspace(req, async ({ user, workspace }) => {
     try {
-      const { name, description } = await ZCreateFolderSchema.parseAsync(
+      const { name, description, slug } = await ZCreateFolderSchema.parseAsync(
         await req.json()
       );
 
@@ -84,7 +84,7 @@ export const POST = (req: NextRequest) => {
       const folder = await prisma.folder.create({
         data: {
           name,
-          slug: slugify(name),
+          slug: slug || slugify(name),
           description,
           ownerId: user.id,
           workspaceId: workspace.id,

--- a/lib/zod.ts
+++ b/lib/zod.ts
@@ -33,22 +33,34 @@ export const ZCreateWorkspaceSchema = z.object({
     }),
 });
 
+/*
+Validates a string against specific naming rules
+ * Rules:
+ * 1. Must not begin with '.'
+ * 2. Must not end with '.'
+ * 3. Must not include special characters like !@#$%^&*, but can include '.'
+ * 4. Must not include two dots '..' side by side
+ * 5. Allow spaces and hyphens between characters
+*/
+const FOLDER_NAME_REGEX =
+  /^[a-zA-Z0-9\s-](?:[a-zA-Z0-9\s.-](?!\.))*[a-zA-Z0-9\s-]$|^[a-zA-Z0-9\s-]$/;
+
 export const ZCreateFolderSchema = z.object({
   name: z
     .string()
     .min(1, { message: "Name is required" })
     .max(50, { message: "Name must be less than 50 characters" })
-    .refine(
-      (val) =>
-        /^[^<>:"/\\|?*\x00-\x1F\s.][^<>:"/\\|?*\x00-\x1F\s]*[^<>:"/\\|?*\x00-\x1F\s.]$/.test(
-          val
-        ),
-      {
-        message:
-          'Folder name can not contain spaces or characters like < > : " / \\ | ? * and should not start or end with a dot or space.',
-      }
-    ),
+    .refine((val) => FOLDER_NAME_REGEX.test(val), {
+      message:
+        'Folder name can not contain characters like < > : " / \\ | ? * and should not start or end with a dot or space. Spaces are allowed',
+    }),
   description: z.string().optional(),
+  slug: z
+    .string()
+    .refine((val) => validSlugRegex.test(val), {
+      message:
+        "Slugs can only contain letters, numbers, and hyphens. No spaces or special characters are allowed",
+    }).optional()
 });
 
 export const ZSlugSchema = z.object({

--- a/prisma/migrations/20250615103420_unique_folder_slug/migration.sql
+++ b/prisma/migrations/20250615103420_unique_folder_slug/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[slug]` on the table `folder` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[workspaceId,name]` on the table `folder` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "folder_workspaceId_slug_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "folder_slug_key" ON "folder"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "folder_workspaceId_name_key" ON "folder"("workspaceId", "name");

--- a/prisma/migrations/20250615110653_unique_folder_slug_in_workspace_not_global/migration.sql
+++ b/prisma/migrations/20250615110653_unique_folder_slug_in_workspace_not_global/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[workspaceId,slug]` on the table `folder` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "folder_slug_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "folder_workspaceId_slug_key" ON "folder"("workspaceId", "slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,14 +99,14 @@ model Workspace {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@unique([ownerId, name]) // unique workspace name for each user
-  @@map("workspace")
   @@index([ownerId])
+  @@map("workspace")
 }
 
 model Folder {
   id          String  @id @default(cuid())
   name        String
-  slug        String
+  slug        String  @unique
   description String?
 
   // relations
@@ -122,14 +122,14 @@ model Folder {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  @@unique([workspaceId, slug]) // unique folder slug for each workspace and user
+  @@unique([workspaceId, name]) // unique folder name for each workspace and user
+  @@index([ownerId, workspaceId])
   @@map("folder")
-  @@index([ownerId,workspaceId])
 }
 
 model Snippet {
   id          String  @id @default(cuid())
-  name        String  
+  name        String
   description String?
   code        String
   public      Boolean @default(true) // by default all snips are public
@@ -148,7 +148,7 @@ model Snippet {
   stars    SnippetStar[]
 
   // counts
-  startCount Int @default(0) // denormalize from SnippetStar table => number of rows in SnippetStar
+  startCount   Int @default(0) // denormalize from SnippetStar table => number of rows in SnippetStar
   commentCount Int @default(0) // denormalize from Comment table => number of rows in Comments tables
 
   // metadata
@@ -156,8 +156,8 @@ model Snippet {
   updatedAt DateTime @updatedAt @map("updated_at")
   // expiresAt DateTime : TODO : add this field to keep expiry of 24hrs, 7 days, 30 days.
 
-  @@unique([folderId,name]) // two snips can't have same name inside a folder
-  @@index([authorId,folderId,workspaceId])
+  @@unique([folderId, name]) // two snips can't have same name inside a folder
+  @@index([authorId, folderId, workspaceId])
 }
 
 model Comment {
@@ -176,8 +176,8 @@ model Comment {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
+  @@index([snippetId, authorId])
   @@map("comment")
-  @@index([snippetId,authorId])
 }
 
 model CommentLike {
@@ -194,8 +194,8 @@ model CommentLike {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@unique([commentId, userId]) // a user can like a comment only once
-  @@map("comment_like")
   @@index([userId])
+  @@map("comment_like")
 }
 
 model SnippetStar {
@@ -210,7 +210,7 @@ model SnippetStar {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  @@unique([userId,snippetId]) // a user can star only once
-  @@map("snippet_star")
+  @@unique([userId, snippetId]) // a user can star only once
   @@index([userId])
+  @@map("snippet_star")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,7 +106,7 @@ model Workspace {
 model Folder {
   id          String  @id @default(cuid())
   name        String
-  slug        String  @unique
+  slug        String 
   description String?
 
   // relations
@@ -122,7 +122,8 @@ model Folder {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  @@unique([workspaceId, name]) // unique folder name for each workspace and user
+  @@unique([workspaceId, name]) // unique folder name for each workspace
+  @@unique([workspaceId, slug]) // unique slug in a workspace
   @@index([ownerId, workspaceId])
   @@map("folder")
 }


### PR DESCRIPTION
## Proposed Changes
1. Migrated database schema to apply unique constraint on folder slug, which I undo in next commit because it will make that slug globally unique in folder table. We expect folder slug to be unique only in a workspace.
2. Let user customise and use their own slug for folder